### PR TITLE
refactor(foxDen::OpenSearch): consolidate `secCfg`  and unify role mapping

### DIFF
--- a/nix/modules/nixos/services/databases/opensearch.nix
+++ b/nix/modules/nixos/services/databases/opensearch.nix
@@ -22,117 +22,114 @@ let
       };
     };
 
-  secCfg."config.yml" = (
-    pkgs.writers.writeYAML "config.yml" {
-      _meta = {
-        type = "config";
-        config_version = 2;
-      };
-      config = {
-        dynamic = {
-          http = {
-            xff = {
-              enabled = true;
-              internalProxies = "127.0.0.1";
-            };
+  secCfg =
+    let
+      writeEmptyYaml = (
+        name: type:
+        pkgs.writers.writeYAML name {
+          _meta = {
+            inherit type;
+            config_version = 2;
           };
-          authc = {
-            proxy_auth_domain = {
-              http_enabled = true;
-              transport_enabled = true;
-              order = 0;
-              http_authenticator = {
-                type = "proxy";
-                challenge = false;
-                config = {
-                  user_header = "x-auth-user";
-                  roles_header = "x-auth-roles";
+        }
+      );
+    in
+    {
+      "config.yml" = (
+        pkgs.writers.writeYAML "config.yml" {
+          _meta = {
+            type = "config";
+            config_version = 2;
+          };
+          config = {
+            dynamic = {
+              http = {
+                xff = {
+                  enabled = true;
+                  internalProxies = "127.0.0.1";
                 };
               };
-              authentication_backend = {
-                type = "noop";
+              authc = {
+                proxy_auth_domain = {
+                  http_enabled = true;
+                  transport_enabled = true;
+                  order = 0;
+                  http_authenticator = {
+                    type = "proxy";
+                    challenge = false;
+                    config = {
+                      user_header = "x-auth-user";
+                      roles_header = "x-auth-roles";
+                    };
+                  };
+                  authentication_backend = {
+                    type = "noop";
+                  };
+                };
               };
             };
           };
-        };
-      };
-    }
-  );
+        }
+      );
 
-  secCfg."roles.yml" = (
-    pkgs.writers.writeYAML "roles.yml" (
-      {
-        _meta = {
-          type = "roles";
-          config_version = 2;
-        };
-      }
-      // (lib.attrsets.mapAttrs (name: user: {
-        reserved = false;
-        hidden = false;
-        index_permissions = [
+      "roles.yml" = (
+        pkgs.writers.writeYAML "roles.yml" (
           {
-            index_patterns = user.indexPatterns;
-            allowed_actions = [ "*" ];
+            _meta = {
+              type = "roles";
+              config_version = 2;
+            };
           }
-        ];
-        cluster_permissions = [
-          "indices:data/write/bulk"
-          "indices:data/read/scroll"
-        ];
-        tenant_permissions = [ ];
-      }) svcConfig.users)
-    )
-  );
+          // (lib.attrsets.mapAttrs (name: user: {
+            reserved = false;
+            hidden = false;
+            index_permissions = [
+              {
+                index_patterns = user.indexPatterns;
+                allowed_actions = [ "*" ];
+              }
+            ];
+            cluster_permissions = [
+              "indices:data/write/bulk"
+              "indices:data/read/scroll"
+            ];
+            tenant_permissions = [ ];
+          }) svcConfig.users)
+        )
+      );
 
-  secCfg."roles_mapping.yml" = (
-    pkgs.writers.writeYAML "roles_mapping.yml" (
-      {
-        _meta = {
-          type = "rolesmapping";
-          config_version = 2;
-        };
-        all_access = {
-          reserved = true;
-          hidden = false;
-          backend_roles = [ ];
-          hosts = [ ];
-          users = [ "root" ];
-          and_backend_roles = [ ];
-        };
-      }
-      // (lib.attrsets.mapAttrs (name: user: {
-        reserved = false;
-        hidden = false;
-        backend_roles = [ ];
-        hosts = [ ];
-        users = [ name ];
-        and_backend_roles = [ ];
-      }) svcConfig.users)
-    )
-  );
+      "roles_mapping.yml" = (
+        pkgs.writers.writeYAML "roles_mapping.yml" (
+          {
+            _meta = {
+              type = "rolesmapping";
+              config_version = 2;
+            };
+          }
+          // (lib.attrsets.mapAttrs (role: users: {
+            reserved = if builtins.elem role [ "all_access" ] then true else false;
+            hidden = false;
+            backend_roles = [ ];
+            hosts = [ ];
+            inherit users;
+            and_backend_roles = [ ];
+            # Assign users to their role
+          }) ({ all_access = [ "root" ]; } // (builtins.mapAttrs (n: _: [ n ]) svcConfig.users)))
+        )
+      );
 
-  writeEmptyYaml = (
-    name: type:
-    pkgs.writers.writeYAML name {
-      _meta = {
-        type = type;
-        config_version = 2;
-      };
-    }
-  );
-
-  secCfg."internal_users.yml" = writeEmptyYaml "internal_users.yml" "internalusers";
-  secCfg."nodes_dn.yml" = writeEmptyYaml "nodes_dn.yml" "nodesdn";
-  secCfg."action_groups.yml" = writeEmptyYaml "action_groups.yml" "actiongroups";
-  secCfg."tenants.yml" = writeEmptyYaml "tenants.yml" "tenants";
-  secCfg."whitelist.yml" = writeEmptyYaml "whitelist.yml" "whitelist";
+      "internal_users.yml" = writeEmptyYaml "internal_users.yml" "internalusers";
+      "nodes_dn.yml" = writeEmptyYaml "nodes_dn.yml" "nodesdn";
+      "action_groups.yml" = writeEmptyYaml "action_groups.yml" "actiongroups";
+      "tenants.yml" = writeEmptyYaml "tenants.yml" "tenants";
+      "whitelist.yml" = writeEmptyYaml "whitelist.yml" "whitelist";
+    };
 in
 {
   options.foxDen.services.opensearch =
     with lib.types;
     services.mkOptions {
-      svcName = "opensearch";
+      # svcName = "opensearch"; # TODO: seems redundant?
       name = "OpenSearch";
     }
     // {
@@ -186,8 +183,7 @@ in
           "plugins.security.ssl.transport.enabled" = true;
           "plugins.security.ssl.transport.pemkey_filepath" = "/var/lib/opensearch/config/opensearch.key";
           "plugins.security.ssl.transport.pemcert_filepath" = "/var/lib/opensearch/config/opensearch.crt";
-          "plugins.security.ssl.transport.pemtrustedcas_filepath" =
-            "/var/lib/opensearch/config/opensearch.crt";
+          "plugins.security.ssl.transport.pemtrustedcas_filepath" = "/var/lib/opensearch/config/opensearch.crt";
           "transport.ssl.enforce_hostname_verification" = false;
         };
 
@@ -262,12 +258,11 @@ in
               "${pkgs.coreutils}/bin/mkdir -p /var/lib/opensearch/config/opensearch-security"
             ]
             ++ (lib.attrsets.mapAttrsToList (
-              name: file:
-              "${pkgs.coreutils}/bin/cp ${file} /var/lib/opensearch/config/opensearch-security/${name}"
+              name: file: "${pkgs.coreutils}/bin/cp ${file} /var/lib/opensearch/config/opensearch-security/${name}"
             ) secCfg)
-            ++ (map (
-              name: "${pkgs.coreutils}/bin/chmod 600 /var/lib/opensearch/config/opensearch-security/${name}"
-            ) (lib.attrsets.attrNames secCfg))
+            ++ (map (name: "${pkgs.coreutils}/bin/chmod 600 /var/lib/opensearch/config/opensearch-security/${name}") (
+              lib.attrsets.attrNames secCfg
+            ))
             ++ [
               (pkgs.writeShellScript "opensearch-start-post-foxden" ''
                 set -o errexit -o pipefail -o nounset -o errtrace


### PR DESCRIPTION
## Changes Summary:

- Merge scattered top-level `secCfg."x.yml" = …` bindings into a single `let writeEmptyYaml = …; in { … }` expression, scoping `writeEmptyYaml` as a local helper instead of a top-level binding
- Unify `roles_mapping.yml` generation: replace the separate hardcoded `all_access` block plus a per-user `mapAttrs` with a single `mapAttrs` over `{ all_access = [ "root" ]; } // (builtins.mapAttrs (n: _: [ n ]) svcConfig.users)`, deriving `reserved` via `builtins.elem`
- Comment out `svcName = "opensearch"` in `mkOptions` with a TODO
- Reflow multiline lambda expressions in `mapAttrsToList`/`map` calls to single lines

## Note

- Preliminary tested with `nix eval '.#nixosConfigurations.bengalfox.config.systemd.services.opensearch-security.serviceConfig.ExecStart'`
- Backport from: https://github.com/magic0whi/nixos-config/commit/3b55955e2291ed58b8698d31a93e04fabf068c7b

## AI Disclosure
I used Claude Sonnet 4.6 to assist in
- Summarize my changes and generate the commit messages